### PR TITLE
Clearing header from undefined implementation

### DIFF
--- a/Clp/src/OsiClp/OsiClpSolverInterface.hpp
+++ b/Clp/src/OsiClp/OsiClpSolverInterface.hpp
@@ -338,6 +338,7 @@ public:
   void stopFastDual();
   /// Sets integer tolerance and increment
   void setStuff(double tolerance, double increment);
+#ifdef CONFLICT_CUTS
   /// Return a conflict analysis cut from small model
   OsiRowCut *smallModelCut(const double *originalLower, const double *originalUpper,
     int numberRowsAtContinuous, const int *whichGenerator,
@@ -349,7 +350,7 @@ public:
     int numberRowsAtContinuous, const int *whichGenerator,
     int typeCut = 0);
   //@}
-
+#endif
   //---------------------------------------------------------------------------
   /**@name Problem information methods
      

--- a/Clp/src/OsiClp/OsiClpSolverInterface.hpp
+++ b/Clp/src/OsiClp/OsiClpSolverInterface.hpp
@@ -969,7 +969,6 @@ public:
   /// This loads a model from a coinModel object - returns number of errors
   virtual int loadFromCoinModel(CoinModel &modelObject, bool keepSolution = false);
 
-  using OsiSolverInterface::readMps;
   /** Read an mps file from the given filename (defaults to Osi reader) - returns
       number of errors (see OsiMpsReader class) */
   virtual int readMps(const char *filename,

--- a/Clp/src/OsiClp/OsiClpSolverInterface.hpp
+++ b/Clp/src/OsiClp/OsiClpSolverInterface.hpp
@@ -177,8 +177,6 @@ public:
 
   /*! \brief Undo setting changes made by #enableSimplexInterface */
   virtual void disableSimplexInterface();
-  /// Copy across enabled stuff from one solver to another
-  void copyEnabledStuff(ClpSimplex &rhs);
 
   /** Perform a pivot by substituting a colIn for colOut in the basis. 
       The status of the leaving variable is given in statOut. Where

--- a/Clp/src/OsiClp/OsiClpSolverInterface.hpp
+++ b/Clp/src/OsiClp/OsiClpSolverInterface.hpp
@@ -174,8 +174,6 @@ public:
      and can be queried by other methods.
   */
   virtual void enableSimplexInterface(bool doingPrimal);
-  /// Copy across enabled stuff from one solver to another
-  void copyEnabledSuff(OsiClpSolverInterface &rhs);
 
   /*! \brief Undo setting changes made by #enableSimplexInterface */
   virtual void disableSimplexInterface();


### PR DESCRIPTION
For Python and Java Native interface code generation, I need to clean-up the headers to remove all the undefined symbol.