### PR TITLE
Fix build on non-x86 non-ARM

### DIFF
--- a/Clp/src/ClpPackedMatrix.cpp
+++ b/Clp/src/ClpPackedMatrix.cpp
@@ -6752,7 +6752,6 @@ ClpPackedMatrix3::ClpPackedMatrix3()
 #elif defined(__arm__)
 #include <arm_neon.h>
 #else
-#include <immintrin.h>
 //#include <fmaintrin.h>
 #endif
 /* Constructor from copy. */

--- a/Clp/src/ClpSimplexDual.cpp
+++ b/Clp/src/ClpSimplexDual.cpp
@@ -3560,7 +3560,6 @@ void moveAndZero(clpTempInfo *info, int type, void *extra)
 #elif defined(__arm__)
 #include <arm_neon.h>
 #else
-#include <immintrin.h>
 //#include <fmaintrin.h>
 #endif
 int ClpSimplexDual::dualColumn0(const CoinIndexedVector *rowArray,


### PR DESCRIPTION
immintrin.h is not necessary on x86 and breaks build e.g. on ppc64.