### PR TITLE
Fix macros for arm specific include

### DIFF
--- a/src/ClpPackedMatrix.cpp
+++ b/src/ClpPackedMatrix.cpp
@@ -6755,7 +6755,7 @@ ClpPackedMatrix3::ClpPackedMatrix3()
 }
 #ifdef _MSC_VER
 #include <intrin.h>
-#elif defined(__arm__)
+#elif defined(__ARM_FEATURE_SIMD32) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #else
 #include <immintrin.h>


### PR DESCRIPTION
They were inconsistent between ClpDualSimplex.cpp and
ClpPackedMatrix.cpp.
The former one seems to be the correct one.