### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default for libClp and libOsiClp

### DIFF
--- a/MSVisualStudio/v16/libClp/libClp.vcxproj
+++ b/MSVisualStudio/v16/libClp/libClp.vcxproj
@@ -125,7 +125,6 @@
       <AdditionalIncludeDirectories>..\..\..\..\CoinUtils\src;..\..\..\..\BuildTools\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_NDEBUG;NDEBUG;CLPLIB_BUILD;WIN32;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/MSVisualStudio/v16/libOsiClp/libOsiClp.vcxproj
+++ b/MSVisualStudio/v16/libOsiClp/libOsiClp.vcxproj
@@ -125,7 +125,6 @@
       <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\CoinUtils\src\;..\..\..\..\Osi\src\Osi\</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>OSICLPLIB_BUILD;WIN32;_MBCS;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions);NDEBUG;_NDEBUG</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
For libClp and libOsiClp, this PR sets RuntimeLibrary (Multithreaded DLL, etc.--how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default values for all configurations by removing explicit values.

All Debug configs were at defaults, but Release were various, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.