### PR TITLE
Add variable type to `for (i = 0; ...` when CLP_DEBUG is defined.

### DIFF
--- a/src/ClpNonLinearCost.cpp
+++ b/src/ClpNonLinearCost.cpp
@@ -1323,7 +1323,7 @@ void ClpNonLinearCost::goBackAll(const CoinIndexedVector *update)
       offset_[iSequence] = 0;
     }
 #ifdef CLP_DEBUG
-    for (i = 0; i < numberRows_ + numberColumns_; i++)
+    for (int i = 0; i < numberRows_ + numberColumns_; i++)
       assert(!offset_[i]);
 #endif
   }


### PR DESCRIPTION
i is not defined in `for (i = 0; i < numberRows_ + numberColumns_; i++)`
