### PR TITLE
fix for OsiObjOffset when reading LP

### DIFF
--- a/src/OsiClp/OsiClpSolverInterface.cpp
+++ b/src/OsiClp/OsiClpSolverInterface.cpp
@@ -6136,7 +6136,7 @@ int OsiClpSolverInterface::readLp(class CoinLpIO &m)
   freeCachedResults();
 
   // set objective function offest
-  setDblParam(OsiObjOffset, 0);
+  setDblParam(OsiObjOffset, m.objectiveOffset());
 
   // set problem name
   setStrParam(OsiProbName, m.getProblemName());


### PR DESCRIPTION
Now gets the offset from CoinLPIO when reading an LP-file.