### PR TITLE
Windows-ci testing for MSVS build

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -30,11 +30,11 @@ jobs:
         ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -65,12 +65,22 @@ jobs:
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
           ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"
+          echo "##################################################"
+          echo "### Extracting Netlib and Miplib3 if available"
+          if [ -d "./Data/Netlib/" ]; then gunzip ./Data/Netlib/*.gz; fi
+          if [ -d "./Data/Miplib3/" ]; then gunzip ./Data/Miplib3/*.gz; fi
+          echo "##################################################"       
         shell: msys2 {0}
       - name: Build project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
         run: |
           msbuild ${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+      - name: Test project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          .\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
       - name: Install project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+﻿
+# Ignore files created during unit tests
+/MSVisualStudio/v17/*.mps
+/MSVisualStudio/v17/*.lp
+/MSVisualStudio/v17/*.out

--- a/MSVisualStudio/v17/Clp.sln
+++ b/MSVisualStudio/v17/Clp.sln
@@ -13,8 +13,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsi", "..\..\..\Osi\MSVi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsiCommonTest", "..\..\..\Osi\MSVisualStudio\v17\libOsiCommonTest\libOsiCommonTest.vcxproj", "{109D6E6F-6D91-460F-86AE-DF27400E09A9}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "OsiClpUnitTest", "OsiClpUnitTest\OsiClpUnitTest.vcxproj", "{75367352-81A3-4707-8560-3005EDC37BBA}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClpExamplesMinimum", "ClpExamplesMinimum\ClpExamplesMinimum.vcxproj", "{52464C0A-31B8-465D-B734-6B05EE15CD7D}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClpExamplesTestBarrier", "ClpExamplesTestBarrier\ClpExamplesTestBarrier.vcxproj", "{F7011C7A-A8B7-47A7-8C6F-1BBD2A332A29}"
@@ -35,6 +33,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		..\..\.github\workflows\release.yml = ..\..\.github\workflows\release.yml
 		..\..\.github\workflows\windows-ci.yml = ..\..\.github\workflows\windows-ci.yml
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0F428A8D-1191-439E-8978-053C8F099329}"
+	ProjectSection(SolutionItems) = preProject
+		ClpTest.cmd = ClpTest.cmd
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{5F5EC484-0FD9-4B32-ACAB-FF00E07DEAB5}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "osiUnitTest", "osiUnitTest\osiUnitTest.vcxproj", "{75367352-81A3-4707-8560-3005EDC37BBA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,14 +91,6 @@ Global
 		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x64.Build.0 = Release|x64
 		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x86.ActiveCfg = Release|Win32
 		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x86.Build.0 = Release|Win32
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x64.ActiveCfg = Debug|x64
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x64.Build.0 = Debug|x64
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x86.ActiveCfg = Debug|Win32
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x86.Build.0 = Debug|Win32
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x64.ActiveCfg = Release|x64
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x64.Build.0 = Release|x64
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x86.ActiveCfg = Release|Win32
-		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x86.Build.0 = Release|Win32
 		{52464C0A-31B8-465D-B734-6B05EE15CD7D}.Debug|x64.ActiveCfg = Debug|x64
 		{52464C0A-31B8-465D-B734-6B05EE15CD7D}.Debug|x64.Build.0 = Debug|x64
 		{52464C0A-31B8-465D-B734-6B05EE15CD7D}.Debug|x86.ActiveCfg = Debug|Win32
@@ -124,12 +123,27 @@ Global
 		{E62F88EE-DC76-489A-99A8-8070099D9D4F}.Release|x64.Build.0 = Release|x64
 		{E62F88EE-DC76-489A-99A8-8070099D9D4F}.Release|x86.ActiveCfg = Release|Win32
 		{E62F88EE-DC76-489A-99A8-8070099D9D4F}.Release|x86.Build.0 = Release|Win32
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x64.ActiveCfg = Debug|x64
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x64.Build.0 = Debug|x64
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x86.ActiveCfg = Debug|Win32
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Debug|x86.Build.0 = Debug|Win32
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x64.ActiveCfg = Release|x64
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x64.Build.0 = Release|x64
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x86.ActiveCfg = Release|Win32
+		{75367352-81A3-4707-8560-3005EDC37BBA}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9} = {0F428A8D-1191-439E-8978-053C8F099329}
+		{52464C0A-31B8-465D-B734-6B05EE15CD7D} = {5F5EC484-0FD9-4B32-ACAB-FF00E07DEAB5}
+		{F7011C7A-A8B7-47A7-8C6F-1BBD2A332A29} = {5F5EC484-0FD9-4B32-ACAB-FF00E07DEAB5}
+		{BDAE37AF-13BF-426A-9629-7E1CE4775C5B} = {5F5EC484-0FD9-4B32-ACAB-FF00E07DEAB5}
 		{434E978C-9259-4FD1-B708-FA653F0FC1C8} = {688FC827-9A38-4AFA-98F4-C301EDAAA305}
+		{0F428A8D-1191-439E-8978-053C8F099329} = {688FC827-9A38-4AFA-98F4-C301EDAAA305}
+		{5F5EC484-0FD9-4B32-ACAB-FF00E07DEAB5} = {688FC827-9A38-4AFA-98F4-C301EDAAA305}
+		{75367352-81A3-4707-8560-3005EDC37BBA} = {0F428A8D-1191-439E-8978-053C8F099329}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F8995EA-6612-4697-B709-B51B0005FDBD}

--- a/MSVisualStudio/v17/ClpTest.cmd
+++ b/MSVisualStudio/v17/ClpTest.cmd
@@ -1,0 +1,48 @@
+@REM This file will run command line tests, comparable to test\makefile.am
+
+@echo off
+SET "BINDIR=%~1"
+SET "SAMPLEDIR=%~2"
+SET "NETLIBDIR=%~3"
+SET "MIPLIBDIR=%~4"
+
+echo INFO: Running %0 %*
+echo INFO: Using bindir '%BINDIR%' and sampledir '%SAMPLEDIR%' and netlibdir '%NETLIBDIR%'
+echo INFO: Miplibdir '%MIPLIBDIR%' is ignored for these tests.
+
+if "%BINDIR%"=="" echo ERROR: No bindir given. && goto :usage
+if not exist "%BINDIR%" echo ERROR: Folder bindir %BINDIR% does not exist. && goto :usage
+
+if "%SAMPLEDIR%"=="" echo ERROR: No sampledir given. && goto :usage
+if not exist %SAMPLEDIR% echo ERROR: Folder sampledir %SAMPLEDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %SAMPLEDIR% cannot contain spaces. && goto :usage
+
+if "%NETLIBDIR%"=="" echo ERROR: No netlibdir given. && goto :usage
+if not exist %NETLIBDIR% echo ERROR: Folder netlibdir %NETLIBDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %NETLIBDIR% cannot contain spaces. && goto :usage
+
+goto :test
+
+:usage
+echo INFO: Usage %0 ^<bindir^> ^<sampledir^> ^<netlibdir^>
+echo INFO: where ^<bindir^> contains the executables, sampledir the sample files and netlibdir the netlib files.
+echo INFO: This script runs automated test.
+echo INFO: The ^<sampledir^> and ^<netlibdir^> must not contain spaces!
+echo INFO: For example: %0 "D:\Some Directory\" ..\..\samples\ "..\..\netlib"
+goto :error
+
+:error
+echo ERROR: An error occurred while running the tests!
+echo INFO: Finished Tests but failed
+exit /b 1
+
+:test
+echo INFO: Starting Tests
+
+"%BINDIR%\clp.exe" -dirSample %SAMPLEDIR% -unitTest -dirNetlib %netlibdir% -netlib
+if not %errorlevel%==0 echo ERROR: Error running clp.exe tests. && goto :error
+
+"%BINDIR%\osiUnitTest.exe" -mpsDir=%SAMPLEDIR% -netlibDir=%NETLIBDIR% -testOsiSolverInterface 
+if not %errorlevel%==0 echo ERROR: Error running osiUnitTest.exe tests. && goto :error
+
+echo INFO: Finished Tests successfully (%ERRORLEVEL%)

--- a/MSVisualStudio/v17/osiUnitTest/osiUnitTest.vcxproj
+++ b/MSVisualStudio/v17/osiUnitTest/osiUnitTest.vcxproj
@@ -43,9 +43,9 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{75367352-81a3-4707-8560-3005edc37bba}</ProjectGuid>
-    <RootNamespace>OsiClpUnitTest</RootNamespace>
+    <RootNamespace>osiUnitTest</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>OsiClpUnitTest</ProjectName>
+    <ProjectName>osiUnitTest</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Add windows-ci testing for the MSVS build for Visual Studio 2022. This included changes to extract the netlib and miplib files and upgrade relevant github actions.