### PR TITLE
Linux and windows ci updates for build warnings

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,32 +18,32 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         build_static: [true, false]
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=clang OSX=10.15
+            flags: CC=clang OSX=12
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=gcc-9 CXX=g++-9 OSX=10.15
+            flags: CC=gcc-11 CXX=g++-11 OSX=12
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=gcc-10 CXX=g++-10 OSX=10.15
+            flags: CC=gcc-12 CXX=g++-12 OSX=12
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -70,7 +70,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools
@@ -85,7 +85,7 @@ jobs:
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -115,7 +115,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
         shell: msys2 {0}
       - name: Upload failed build directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{ matrix.os}}-{{ matrix.arch }}-debug=${{ matrix.debug }}-failedbuild
@@ -133,7 +133,7 @@ jobs:
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.package_suffix }}
           path: dist


### PR DESCRIPTION
For Linux-ci move to ubuntu 22.04 from 18.04 and macos-12 from 10.15.