### PR TITLE
Fix possible buffer overflow in `ClpSimplexOther`

### DIFF
--- a/src/ClpSimplexOther.cpp
+++ b/src/ClpSimplexOther.cpp
@@ -2519,7 +2519,7 @@ int ClpSimplexOther::parametrics(double startingTheta, double &endingTheta, doub
       }
       if (maxTheta < endingTheta) {
         char line[100];
-        sprintf(line, "Crossover considerations reduce ending  theta from %g to %g\n",
+        snprintf(line, sizeof(line), "Crossover considerations reduce ending  theta from %g to %g\n",
           endingTheta, maxTheta);
         handler_->message(CLP_GENERAL, messages_)
           << line << CoinMessageEol;
@@ -2631,7 +2631,7 @@ int ClpSimplexOther::parametrics(double startingTheta, double &endingTheta, doub
         copyModel.dual();
         if (copyModel.problemStatus()) {
           char line[100];
-          sprintf(line, "Can not get to theta of %g\n", startingTheta);
+          snprintf(line, sizeof(line), "Can not get to theta of %g\n", startingTheta);
           handler_->message(CLP_GENERAL, messages_)
             << line << CoinMessageEol;
           canTryQuick = false; // do slowly to get exact amount
@@ -2656,7 +2656,7 @@ int ClpSimplexOther::parametrics(double startingTheta, double &endingTheta, doub
   }
   perturbation_ = savePerturbation;
   char line[100];
-  sprintf(line, "Ending theta %g\n", endingTheta);
+  snprintf(line, sizeof(line), "Ending theta %g\n", endingTheta);
   handler_->message(CLP_GENERAL, messages_)
     << line << CoinMessageEol;
   return problemStatus_;
@@ -2675,8 +2675,8 @@ int ClpSimplexOther::parametrics(const char *dataFile)
     return -2;
   }
 
-  if (!fgets(line, 200, fp)) {
-    sprintf(line, "Empty parametrics file %s?", dataFile);
+  if (!fgets(line, sizeof(line), fp)) {
+    snprintf(line, sizeof(line), "Empty parametrics file %s?", dataFile);
     handler_->message(CLP_GENERAL, messages_)
       << line << CoinMessageEol;
     fclose(fp);
@@ -2752,14 +2752,15 @@ int ClpSimplexOther::parametrics(const char *dataFile)
   if (intervalTheta >= endTheta)
     intervalTheta = 0.0;
   if (!good) {
-    sprintf(line, "Odd first line %s on file %s?", line, dataFile);
+    char line2[300];
+    snprintf(line2, sizeof(line2), "Odd first line %s on file %s?", line, dataFile);
     handler_->message(CLP_GENERAL, messages_)
-      << line << CoinMessageEol;
+      << line2 << CoinMessageEol;
     fclose(fp);
     return -2;
   }
-  if (!fgets(line, 200, fp)) {
-    sprintf(line, "Not enough records on parametrics file %s?", dataFile);
+  if (!fgets(line, sizeof(line), fp)) {
+    snprintf(line, sizeof(line), "Not enough records on parametrics file %s?", dataFile);
     handler_->message(CLP_GENERAL, messages_)
       << line << CoinMessageEol;
     fclose(fp);
@@ -2843,7 +2844,7 @@ int ClpSimplexOther::parametrics(const char *dataFile)
       int nLine = 0;
       //int nBadLine = 0;
       int nBadName = 0;
-      while (fgets(line, 200, fp)) {
+      while (fgets(line, sizeof(line), fp)) {
         if (!strncmp(line, "ENDATA", 6) || !strncmp(line, "COLUMN", 6))
           break;
         nLine++;
@@ -2920,11 +2921,11 @@ int ClpSimplexOther::parametrics(const char *dataFile)
             strcpy(saveLine, line);
         }
       }
-      sprintf(line, "%d Row fields and %d records", nAcross, nLine);
+      snprintf(line, sizeof(line), "%d Row fields and %d records", nAcross, nLine);
       handler_->message(CLP_GENERAL, messages_)
         << line << CoinMessageEol;
       if (nBadName) {
-        sprintf(line, " ** %d records did not match on name/sequence, first bad %s", nBadName, saveLine);
+        snprintf(line, sizeof(line), " ** %d records did not match on name/sequence, first bad %s", nBadName, saveLine);
         handler_->message(CLP_GENERAL, messages_)
           << line << CoinMessageEol;
         returnCode = -1;
@@ -2935,7 +2936,7 @@ int ClpSimplexOther::parametrics(const char *dataFile)
       }
       delete[] rowNames;
     } else {
-      sprintf(line, "Duplicate or unknown keyword - or name/number fields wrong");
+      snprintf(line, sizeof(line), "Duplicate or unknown keyword - or name/number fields wrong");
       handler_->message(CLP_GENERAL, messages_)
         << line << CoinMessageEol;
       returnCode = -1;
@@ -2943,8 +2944,8 @@ int ClpSimplexOther::parametrics(const char *dataFile)
     }
   }
   if (good && (!strncmp(line, "COLUMN", 6) || !strncmp(line, "column", 6))) {
-    if (!fgets(line, 200, fp)) {
-      sprintf(line, "Not enough records on parametrics file %s after COLUMNS?", dataFile);
+    if (!fgets(line, sizeof(line), fp)) {
+      snprintf(line, sizeof(line), "Not enough records on parametrics file %s after COLUMNS?", dataFile);
       handler_->message(CLP_GENERAL, messages_)
         << line << CoinMessageEol;
       fclose(fp);
@@ -3015,7 +3016,7 @@ int ClpSimplexOther::parametrics(const char *dataFile)
         int nLine = 0;
         //int nBadLine = 0;
         int nBadName = 0;
-        while (fgets(line, 200, fp)) {
+        while (fgets(line, sizeof(line), fp)) {
           if (!strncmp(line, "ENDATA", 6))
             break;
           nLine++;
@@ -3094,11 +3095,11 @@ int ClpSimplexOther::parametrics(const char *dataFile)
               strcpy(saveLine, line);
           }
         }
-        sprintf(line, "%d Column fields and %d records", nAcross, nLine);
+        snprintf(line, sizeof(line), "%d Column fields and %d records", nAcross, nLine);
         handler_->message(CLP_GENERAL, messages_)
           << line << CoinMessageEol;
         if (nBadName) {
-          sprintf(line, " ** %d records did not match on name/sequence, first bad %s", nBadName, saveLine);
+          snprintf(line, sizeof(line), " ** %d records did not match on name/sequence, first bad %s", nBadName, saveLine);
           handler_->message(CLP_GENERAL, messages_)
             << line << CoinMessageEol;
           returnCode = -1;
@@ -3109,7 +3110,7 @@ int ClpSimplexOther::parametrics(const char *dataFile)
         }
         delete[] columnNames;
       } else {
-        sprintf(line, "Duplicate or unknown keyword - or name/number fields wrong");
+        snprintf(line, sizeof(line), "Duplicate or unknown keyword - or name/number fields wrong");
         handler_->message(CLP_GENERAL, messages_)
           << line << CoinMessageEol;
         returnCode = -1;
@@ -3665,7 +3666,7 @@ int ClpSimplexOther::parametrics(double startingTheta, double &endingTheta,
   delete rowArray_[5];
   rowArray_[5] = NULL;
   char line[100];
-  sprintf(line, "Ending theta %g\n", endingTheta);
+  snprintf(line, sizeof(line), "Ending theta %g\n", endingTheta);
   handler_->message(CLP_GENERAL, messages_)
     << line << CoinMessageEol;
   return problemStatus_;
@@ -6318,7 +6319,7 @@ ClpSimplexOther::gubVersion(int *whichRows, int *whichColumns,
       }
     }
     if (!numberNormal) {
-      sprintf(message, "Putting back one gub row to make non-empty");
+      snprintf(message, sizeof(message), "Putting back one gub row to make non-empty");
       handler_->message(CLP_GENERAL2, messages_)
         << message << CoinMessageEol;
       rowIsGub[smallestGubRow] = -1;
@@ -6532,7 +6533,7 @@ ClpSimplexOther::gubVersion(int *whichRows, int *whichColumns,
         }
       }
     }
-    sprintf(message, "** Before adding matrix there are %d rows and %d columns",
+    snprintf(message, sizeof(message), "** Before adding matrix there are %d rows and %d columns",
       model2->numberRows(), model2->numberColumns());
     handler_->message(CLP_GENERAL2, messages_)
       << message << CoinMessageEol;


### PR DESCRIPTION
Using more safe function that performs check buffer length.

Also use sizeof instead of hard-coded size as numeric literal. 