### PR TITLE
add function to C interface to access ClpSimplex* member of Clp_Simplex*

### DIFF
--- a/src/Clp_C_Interface.cpp
+++ b/src/Clp_C_Interface.cpp
@@ -1385,6 +1385,12 @@ ClpSolveSetIntProperty(setInfeasibleReturn)
                                                 ClpSolveGetIntProperty(substitution)
                                                   ClpSolveSetIntProperty(setSubstitution)
 
+/** give pointer to ClpSimplex object (C++ class) */
+void* CLP_LINKAGE Clp_getClpSimplex(Clp_Simplex *model)
+{
+   return static_cast<void*>(model->model_);
+}
+
 #if defined(__MWERKS__)
 #pragma export off
 #endif

--- a/src/Clp_C_Interface.h
+++ b/src/Clp_C_Interface.h
@@ -546,8 +546,14 @@ CLPLIB_EXPORT void CLP_LINKAGE ClpSolve_setPresolveActions(Clp_Solve *, int acti
 
 CLPLIB_EXPORT int CLP_LINKAGE ClpSolve_substitution(Clp_Solve *);
 CLPLIB_EXPORT void CLP_LINKAGE ClpSolve_setSubstitution(Clp_Solve *, int value);
-
 /*@}*/
+
+/**@name Functions for expert users */
+/*@{*/
+/** gives pointer to ClpSimplex object (C++ class), return should be cast to ClpSimplex* */
+CLPLIB_EXPORT void* CLP_LINKAGE Clp_getClpSimplex(Clp_Simplex *model);
+/*@}*/
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
@amigalemming This should take care of #283.

You can use defines `CLP_VERSION_MAJOR` and `CLP_VERSION_MINOR` to distinguish current master from Clp 1.17. Since master has no version yet, `CLP_VERSION_MAJOR` and `CLP_VERSION_MINOR` are both 9999 at the moment.
They will probably move to 1 and 18 or 2 and 0, if there will ever be an attempt of doing a release.
So you may want to check for `CLP_VERSION_MAJOR > 1 || CLP_VERSION_MINOR > 17` in your code.