### PR TITLE
Initialize variables for presolve to prevent MSVS error C4703

### DIFF
--- a/src/ClpSimplexOther.cpp
+++ b/src/ClpSimplexOther.cpp
@@ -1807,9 +1807,9 @@ ClpSimplexOther::crunch(double *rhs, int *whichRow, int *whichColumn,
   const int *row = matrix_->getIndices();
   const CoinBigIndex *columnStart = matrix_->getVectorStarts();
   const int *columnLength = matrix_->getVectorLengths();
-  char * flags;
-  double * maxdown;
-  double * maxup;
+  char * flags = NULL;
+  double * maxdown = NULL;
+  double * maxup = NULL;
   if (takeOutSome) {
     flags = new char [numberRows_];
     maxdown = new double [2*numberRows_];


### PR DESCRIPTION
Fix for error/warning C4703 for MSVS builds: Potentially uninitialized local pointer variable used for flags, maxdown and maxup. 

The original code _initializes_ flags, maxdown and maxup only "if(takeOutSome)", and only _uses_ these variables under the same condition (good). Unfortunately, the MSVS linker still believes this is potentially wrong--which is incorrect. Due to other linker options (/sdl), these (erroneous) warnings are treated as errors and therefore stop the build. The easiest way to workaround this is to initialize the variables.