### PR TITLE
don't call memcpy with potential nullptr

### DIFF
--- a/src/ClpModelParameters.hpp
+++ b/src/ClpModelParameters.hpp
@@ -82,7 +82,8 @@ template < class T >
 inline void
 ClpDisjointCopyN(const T *array, const CoinBigIndex size, T *newArray)
 {
-  memcpy(reinterpret_cast< void * >(newArray), array, size * sizeof(T));
+  if (array)
+    memcpy(reinterpret_cast< void * >(newArray), array, size * sizeof(T));
 }
 /// And set
 template < class T >


### PR DESCRIPTION
that is undefined
caught by clang ubsan

avoids alarms like

Clp/src/ClpModelParameters.hpp:85:48: runtime error: null pointer passed as argument 2, which is declared to never be null
