### PR TITLE
remove extern "C" around cholmod.h include

### DIFF
--- a/src/ClpCholeskyUfl.cpp
+++ b/src/ClpCholeskyUfl.cpp
@@ -4,17 +4,17 @@
 
 #include "ClpConfig.h"
 
-extern "C" {
 #ifndef CLP_HAS_CHOLMOD
 #ifndef CLP_HAS_AMD
 #error "Need to have AMD or CHOLMOD to compile ClpCholeskyUfl."
 #else
+extern "C" {  // for very old AMD versions, as coming with old versions of Glpk
 #include "amd.h"
+}
 #endif
 #else
 #include "cholmod.h"
 #endif
-}
 
 #include "CoinPragma.hpp"
 #include "ClpCholeskyUfl.hpp"


### PR DESCRIPTION
SuiteSparse may include C++ headers now, which gives failures when inside an `extern "C"` block.